### PR TITLE
Update Country.php

### DIFF
--- a/src/Country.php
+++ b/src/Country.php
@@ -278,7 +278,7 @@ class Country
      */
     public function getLanguage($languageCode = null): ?string
     {
-        $languageCode = $languageCode ? mb_strtoupper($languageCode) : null;
+        $languageCode = $languageCode ? mb_strtolower($languageCode) : null;
 
         return $this->get("languages.{$languageCode}") ?: (current($this->get('languages', [])) ?: null);
     }


### PR DESCRIPTION
In reference of #117 

Change `mb_strtoupper` into `mb_strtolower` in order to get a match using `get("languages.{$languageCode}")`

With `mb_strtoupper` the function will have `languages.ITA` for example instead of correct `languages.ita`