### PR TITLE
Fix longlist for currencies

### DIFF
--- a/src/CurrencyLoader.php
+++ b/src/CurrencyLoader.php
@@ -29,26 +29,20 @@ class CurrencyLoader
         $currencies = [];
 
         foreach ($countries as $country) {
+            if (empty($country['currency'])) {
+                continue;
+            }
+
             if ($longlist) {
                 foreach ($country['currency'] as $currency => $details) {
-                    $currencies[$currency] = $longlist ? $details : $currency;
+                    $currencies[$currency] = $details;
                 }
             } else {
-                $currencies[] = $country['currency'];
+                $currencies[$country['currency']] = $country['currency'];
             }
         }
 
-        if (! $longlist) {
-            $currencies = array_filter(array_unique($currencies), function ($item) {
-                return is_string($item);
-            });
-
-            sort($currencies);
-
-            $currencies = array_combine($currencies, $currencies);
-        } else {
-            ksort($currencies);
-        }
+        ksort($currencies);
 
         static::$currencies[$list] = $currencies;
 

--- a/src/CurrencyLoader.php
+++ b/src/CurrencyLoader.php
@@ -21,26 +21,37 @@ class CurrencyLoader
     {
         $list = $longlist ? 'longlist' : 'shortlist';
 
-        if (! isset(static::$currencies[$list])) {
-            $countries = CountryLoader::countries($longlist);
+        if (isset(static::$currencies[$list])) {
+            return static::$currencies[$list];
+        }
 
-            foreach ($countries as $country) {
-                if ($longlist) {
-                    foreach ($country['currency'] as $currency => $details) {
-                        static::$currencies[$list][$currency] = $longlist ? $details : $currency;
-                    }
-                } else {
-                    static::$currencies[$list][] = $country['currency'];
+        $countries = CountryLoader::countries($longlist);
+        $currencies = [];
+
+        foreach ($countries as $country) {
+            if ($longlist) {
+                foreach ($country['currency'] as $currency => $details) {
+                    $currencies[$currency] = $longlist ? $details : $currency;
                 }
+            } else {
+                $currencies[] = $country['currency'];
             }
         }
 
-        $currencies = array_filter(array_unique(static::$currencies[$list]), function ($item) {
-            return is_string($item);
-        });
+        if (! $longlist) {
+            $currencies = array_filter(array_unique(static::$currencies[$list]), function ($item) {
+                return is_string($item);
+            });
 
-        sort($currencies);
+            sort($currencies);
 
-        return array_combine($currencies, $currencies);
+            $currencies = array_combine($currencies, $currencies);
+        } else {
+            ksort($currencies);
+        }
+
+        static::$currencies[$list] = $currencies;
+
+        return $currencies;
     }
 }

--- a/src/CurrencyLoader.php
+++ b/src/CurrencyLoader.php
@@ -39,7 +39,7 @@ class CurrencyLoader
         }
 
         if (! $longlist) {
-            $currencies = array_filter(array_unique(static::$currencies[$list]), function ($item) {
+            $currencies = array_filter(array_unique($currencies), function ($item) {
                 return is_string($item);
             });
 

--- a/tests/Unit/CurrencyLoaderTest.php
+++ b/tests/Unit/CurrencyLoaderTest.php
@@ -27,7 +27,7 @@ class CurrencyLoaderTest extends TestCase
     /** @test */
     public function it_returns_courrencies_shortlist()
     {
-        $this->assertEquals(165, count(CurrencyLoader::currencies()));
+        $this->assertEquals(156, count(CurrencyLoader::currencies()));
         $this->assertArrayHasKey('EGP', CurrencyLoader::currencies());
         $this->assertIsString(CurrencyLoader::currencies()['EGP']);
         $this->assertEquals('EGP', CurrencyLoader::currencies()['EGP']);


### PR DESCRIPTION
Currently, if you execute

```php
$currencies = currencies(true);
```
or
```php
$currencies = \Rinvex\Country\CurrencyLoader::currencies(true);
```
the resulting array will be empty.

The reason is the filtering:

https://github.com/rinvex/countries/blob/c6f08bdb66e37a01007213c5e88f6a7a1fa33933/src/CurrencyLoader.php#L38-L44

This only works for the shortlist, but not the longlist. And even if the filtering was removed, the subsequent `sort()` would not work (since it would need to be `ksort` in that case) and the `array_merge` would destroy the longlist too.

This PR actually changes a few more things:

1. It implements an early out with the static variable.
2. It only uses `ksort` for the longlist (no filtering should be necessary, as the associative array by ISO code is unique already).
3. It stores the final result for the shortlist and longlist in the static variable, including filtering and sorting.