### PR TITLE
composer: allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         }
     ],
     "require": {
-        "php": "^7.4.0"
+        "php": "^7.4|^8.0"
     },
     "require-dev": {
         "codedungeon/phpunit-result-printer": "^0.27.0",


### PR DESCRIPTION
Hi,

I'm trying to upgrade my project to PHP 8 here: https://github.com/TomasVotruba/friendsofphp.org/pull/176

This package is the last dependency to allow it