### PR TITLE
Fixed bug that prevents default value to be returned from get method …

### DIFF
--- a/src/Country.php
+++ b/src/Country.php
@@ -94,7 +94,7 @@ class Country
         }
 
         if (array_key_exists($key, $array)) {
-            return $array[$key];
+            return $array[$key] ?? $default;
         }
 
         foreach (explode('.', $key) as $segment) {


### PR DESCRIPTION
…when attribute exists but is null.

Also fixes #64.
Test is already present (`it_returns_null_when_missing_tld`).