### PR TITLE
PHP 8.4 fix : Implicitly marking parameter as nullable is deprecated

### DIFF
--- a/src/CountryLoader.php
+++ b/src/CountryLoader.php
@@ -122,7 +122,7 @@ class CountryLoader
      *
      * @return array
      */
-    protected static function filter($items, callable $callback = null)
+    protected static function filter($items, ?callable $callback = null)
     {
         if ($callback) {
             return array_filter($items, $callback, ARRAY_FILTER_USE_BOTH);


### PR DESCRIPTION
WARNING: Rinvex\Country\CountryLoader::filter(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in ...\vendor\rinvex\countries\src\CountryLoader.php on line 125