### PR TITLE
Remove redundant check in CurrencyLoader

### DIFF
--- a/src/CurrencyLoader.php
+++ b/src/CurrencyLoader.php
@@ -26,7 +26,7 @@ class CurrencyLoader
                 if ($longlist) {
                     foreach ($country['currency'] as $currency => $details) {
                         if ($currency) {
-                            static::$currencies[$list][$currency] = $longlist ? $details : $currency;
+                            static::$currencies[$list][$currency] = $details;
                         }
                     }
                 } elseif ($country['currency']) {


### PR DESCRIPTION
As we are in the `if ($longlist)` branch, `$longlist` is always true, and therefore the ternary operator is redundant.