### PR TITLE
Improve return types with conditional statements

### DIFF
--- a/src/CountryLoader.php
+++ b/src/CountryLoader.php
@@ -23,7 +23,7 @@ class CountryLoader
      *
      * @throws CountryLoaderException
      *
-     * @return Country|array
+     * @return ($hydrate is true ? Country : array)
      */
     public static function country($code, $hydrate = true)
     {
@@ -44,7 +44,7 @@ class CountryLoader
      *
      * @throws CountryLoaderException
      *
-     * @return array
+     * @return ($hydrate is true ? array<string, Country> : array<string, array>)
      */
     public static function countries($longlist = false, $hydrate = false)
     {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -13,7 +13,7 @@ if (! function_exists('country')) {
      * @param string $code
      * @param bool   $hydrate
      *
-     * @return Country|array
+     * @return ($hydrate is true ? Country : array)
      */
     function country($code, $hydrate = true)
     {
@@ -28,7 +28,7 @@ if (! function_exists('countries')) {
      * @param bool $longlist
      * @param bool $hydrate
      *
-     * @return array
+     * @return ($hydrate is true ? array<string, Country> : array<string, array>)
      */
     function countries($longlist = false, $hydrate = false)
     {


### PR DESCRIPTION
The `country()` and `countries()` helpers' return types depend on the value of the `$hydrate` parameter: in particular, `country()` might return either an array or a `Country` instance. This is a problem for static analysis tools like PHPStan, that are unable to correctly determine the return type.

This PR improves the return type annotations to conditionally determine the return type based on the the value of the parameter.

This is based on PHPStan syntax. Alternatively, if you prefer not to change the `@return` annotation, it is possible to add this as `@phpstan-return` annotation.